### PR TITLE
chore: update gwa-cli download link and change init to login command

### DIFF
--- a/.github/sample.gwa.yml
+++ b/.github/sample.gwa.yml
@@ -1,13 +1,13 @@
 services:
   - name: test-action
     host: test.d2723f-dev.svc
-    tags: [ ns.nr-gh-action ]
+    tags: [ ns.bcgov-nr-action ]
     port: 80
     protocol: http
     retries: 0
     routes:
       - name: test-action-route
-        tags: [ ns.nr-gh-action ]
+        tags: [ ns.bcgov-nr-action ]
         hosts:
           - test-action.api.gov.bc.ca
         paths:
@@ -20,7 +20,7 @@ services:
         path_handling: v0
         plugins:  
           - name: key-auth
-            tags: [ ns.nr-gh-action ]
+            tags: [ ns.bcgov-nr-action ]
             protocols: [ http, https ]
             config:
               key_names: ["X-API-KEY"]
@@ -28,7 +28,7 @@ services:
               hide_credentials: true
               key_in_body: false
           - name: acl
-            tags: [ ns.nr-gh-action ]
+            tags: [ ns.bcgov-nr-action ]
             config:
               hide_groups_header: true
               allow: [ "F87926EE" ]

--- a/action.yml
+++ b/action.yml
@@ -32,17 +32,18 @@ runs:
     - name: Publish API
       shell: bash
       run: |
-        curl -L -O https://github.com/bcgov/gwa-cli/releases/download/v1.3.1/gwa_v1.3.1_linux_x64.zip
-        unzip gwa_v1.3.1_linux_x64.zip        
+        curl -L -O https://github.com/bcgov/gwa-cli/releases/download/v3.0.7/gwa_Linux_x86_64.tgz
+        tar -xvzf gwa_Linux_x86_64.tgz
 
         ENV="-P"
         if [ "${{ inputs.production }}" == "false" ]; then
           ENV="-T"
         fi
 
-        ./gwa init ${ENV} \
-          --namespace=${{ inputs.namespace }} \
+        ./gwa login \
           --client-id=${{ inputs.client_id }} \
           --client-secret=${{ inputs.client_secret }}
+          
+        ./gwa config set gateway ${{ inputs.namespace }}
 
         ./gwa pg ${{ inputs.file }}


### PR DESCRIPTION
Updating gwa client to conform with the new API version as described [in here](https://developer.gov.bc.ca/docs/default/component/aps-infra-platform-docs/reference/gwa-commands/)